### PR TITLE
Add code of conduct and contributing files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+For the code of conduct for Institute for Nonprofit News projects on GitHub, please see https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+For general information about contributing to Institute for Nonprofit News projects on GitHub, please see https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md


### PR DESCRIPTION
The files introduced in this PR link to the unified file in INN/docs, https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md

This is done to prevent duplication. If necessary, we can split the files later, or make it so INN/docs links to this repo for the CoC and contributing files.

As described in #2, INN/docs and INN/Largo have their own contributing files.

Resolves #2. Resolves #1.