### PR TITLE
Start a security template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Responsibly reporting security vulnerabilities
+
+If you believe you have found a security vulnerability in a software project maintained by INN, there are many ways to contact us without filing a GitHub issue:
+
+- Send an email to support@inn.org: this forwards TKTK
+- Send an email to nerds@inn.org: this forwards TKTK, bypassing TKTK
+- Send physical mail to TKTK address


### PR DESCRIPTION
This starts the work of adding [a security policy](https://help.github.com/en/articles/adding-a-security-policy-to-your-repository) for the INN organization on GitHub, which will provide answers to people who want to report security vulnerabilities in INN's products. Resolves https://github.com/INN/.github/issues/6

## Research

- WordPress's guidelines: https://make.wordpress.org/core/handbook/testing/reporting-security-vulnerabilities/
- Oracle's responsible disclosure page: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html

## Questions

- [ ] What email address should we send people to? Should we tell people how that email is routed if they are concerned about the chain of custody of such emails?
- [ ] What physical address should people send mail to in event they do not want to, or are unable to, send an email? (Probably the INN main office, to a specific name care of INN)
- [ ] What procedures do we need to implement on our end for the handling of security vulnerability reports? Where should we store those procedures? (INN/docs, likely)
- [ ] Should we talk about email encryption, and if so, whose keys should we tell people to use, or where can we point people to find the keys used by INN's humans? 
- [ ] How should we thank people for reporting responsibly?
- [ ] Do we want to set up something like HackerOne?